### PR TITLE
Fix List support.

### DIFF
--- a/Scripts/Editor/SceneViewPickerPropertyDrawer.cs
+++ b/Scripts/Editor/SceneViewPickerPropertyDrawer.cs
@@ -195,7 +195,7 @@ namespace RoyTheunissen.SceneViewPicker
             if (type.IsArray)
                 return true;
 
-            if (type.IsGenericTypeDefinition && type.GetGenericTypeDefinition() == typeof(List<>))
+            if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(List<>))
                 return true;
 
             return false;


### PR DESCRIPTION
When trying to use this with a list of custom MonoBehaviours it didn't show up. After a bit fo testing found that this should be changed. 

=======
I was using 2021.2.0b1 I don't think that shouls influence anything.